### PR TITLE
value.getVec()がarrayのコピーを返すようにした

### DIFF
--- a/src/value.ts
+++ b/src/value.ts
@@ -82,7 +82,7 @@ export class Value extends EventTarget<Value> {
     if (v === null) {
       return [];
     } else {
-      return v;
+      return v.slice();
     }
   }
   /**


### PR DESCRIPTION
fix #26
