### PR TITLE
syncinitend

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -66,9 +66,15 @@ export class Client extends Member {
 
   /**
    * 他のmemberにアクセスする
+   *
+   * ver1.7〜: member名が空文字列ならthisを返す
    */
   member(member: string) {
-    return new Member(this, member);
+    if (member === "") {
+      return this as Member;
+    } else {
+      return new Member(this, member);
+    }
   }
   /**
    * サーバーに接続されている他のmemberのリストを得る。
@@ -99,6 +105,13 @@ export class Client extends Member {
    */
   get serverVersion() {
     return this.dataCheck().svrVersion;
+  }
+  /**
+   * サーバーのホスト名
+   * @since ver1.7
+   */
+  get serverHostName() {
+    return this.dataCheck().svrHostName;
   }
   /**
    * webcfaceに出力するLogAppender

--- a/src/clientData.ts
+++ b/src/clientData.ts
@@ -34,6 +34,8 @@ export class ClientData {
   eventEmitter: EventEmitter;
   svrName = "";
   svrVersion = "";
+  selfMemberId = 0;
+  svrHostName = "";
   pingStatus: Map<number, number>;
   pingStatusReq = false;
   pingStatusReqSend = false;
@@ -106,6 +108,9 @@ export class ClientData {
     return this.selfMemberName === member;
   }
   getMemberNameFromId(id: number) {
+    if(id == this.selfMemberId){
+      return this.selfMemberName;
+    }
     for (const [n, i] of this.memberIds.entries()) {
       if (i === id) {
         return n;
@@ -114,7 +119,11 @@ export class ClientData {
     return "";
   }
   getMemberIdFromName(name: string) {
-    return this.memberIds.get(name) || 0;
+    if (name === this.selfMemberName) {
+      return this.selfMemberId;
+    } else {
+      return this.memberIds.get(name) || 0;
+    }
   }
   /**
    * messageQueueを消費

--- a/src/clientWs.ts
+++ b/src/clientWs.ts
@@ -232,10 +232,12 @@ export function onMessage(
   const syncMembers: string[] = [];
   for (const msg of messages) {
     switch (msg.kind) {
-      case Message.kind.svrVersion: {
-        const dataR = msg as Message.SvrVersion;
+      case Message.kind.syncInitEnd: {
+        const dataR = msg as Message.SyncInitEnd;
         data.svrName = dataR.n;
         data.svrVersion = dataR.v;
+        data.selfMemberId = dataR.m;
+        data.svrHostName = dataR.h;
         break;
       }
       case Message.kind.ping: {

--- a/src/message.ts
+++ b/src/message.ts
@@ -60,7 +60,7 @@ export const kind = {
   log: 85,
   logReq: 86,
   sync: 87,
-  svrVersion: 88,
+  syncInitEnd: 88,
   ping: 89,
   pingStatus: 90,
   pingStatusReq: 91,
@@ -263,10 +263,12 @@ export interface SyncInit {
   v: string;
   a: string;
 }
-export interface SvrVersion {
+export interface SyncInitEnd {
   kind: 88;
   n: string;
   v: string;
+  m: number;
+  h: string;
 }
 export interface Sync {
   kind: 87;
@@ -358,7 +360,7 @@ export type AnyMessage =
   | Canvas2DRes
   | SyncInit
   | Sync
-  | SvrVersion
+  | SyncInitEnd
   | Ping
   | PingStatus
   | PingStatusReq

--- a/test/client.spec.ts
+++ b/test/client.spec.ts
@@ -70,6 +70,11 @@ describe("Client Tests", function () {
       assert.instanceOf(v, Member);
       assert.strictEqual(v.name, "a");
     });
+    it("returns Member object with self name if given name is empty", function () {
+      const v = wcli.member("");
+      assert.instanceOf(v, Member);
+      assert.strictEqual(v.name, wcli.name);
+    });
   });
   describe("#members()", function () {
     it("returns list of members in data.valueStore.entry", function () {
@@ -99,6 +104,12 @@ describe("Client Tests", function () {
     it("returns data.svrVersion", function () {
       data.svrVersion = "a";
       assert.strictEqual(wcli.serverVersion, "a");
+    });
+  });
+  describe("#serverHostName", function () {
+    it("returns data.svrHostName", function () {
+      data.svrHostName = "a";
+      assert.strictEqual(wcli.serverHostName, "a");
     });
   });
   describe("#logAppender", function () {
@@ -212,10 +223,12 @@ describe("Client Tests", function () {
       it("receiving server version", function (done) {
         wcli.start();
         setTimeout(() => {
-          wssSend({ kind: Message.kind.svrVersion, n: "a", v: "1" });
+          wssSend({ kind: Message.kind.syncInitEnd, n: "a", v: "1", m: 5, h: "b" });
           setTimeout(() => {
             assert.strictEqual(data.svrName, "a");
             assert.strictEqual(data.svrVersion, "1");
+            assert.strictEqual(data.svrHostName, "b");
+            assert.strictEqual(data.selfMemberId, 5);
             done();
           }, 10);
         }, 10);

--- a/test/member.spec.ts
+++ b/test/member.spec.ts
@@ -205,6 +205,11 @@ describe("Member Tests", function () {
       data.pingStatus.set(1, 10);
       assert.strictEqual(member("a").pingStatus, 10);
     });
+    it("returns pingStatus of client itself if selfMemberId is known", function () {
+      data.selfMemberId = 5;
+      data.pingStatus.set(5, 10);
+      assert.strictEqual(member(data.selfMemberName).pingStatus, 10);
+    });
     it("sets pingStatusReq", function () {
       member("a").pingStatus;
       assert.isTrue(data.pingStatusReq);


### PR DESCRIPTION
* SyncInitEndメッセージの処理に対応
* Client.serverHostName 追加
* Member.pingStatus でClient自身のping値を取得できるようにした
* Client.member() が引数が空の時thisを返す
