### PR TITLE
func promise

### DIFF
--- a/src/canvas2d.ts
+++ b/src/canvas2d.ts
@@ -211,7 +211,7 @@ export class Canvas2D extends EventTarget<Canvas2D> {
       this.field_
     );
     if (reqId > 0) {
-      this.dataCheck().pushSend([
+      this.dataCheck().pushSendOnline([
         {
           kind: Message.kind.canvas2DReq,
           M: this.member_,

--- a/src/canvas3d.ts
+++ b/src/canvas3d.ts
@@ -428,7 +428,7 @@ export class Canvas3D extends EventTarget<Canvas3D> {
       this.field_
     );
     if (reqId > 0) {
-      this.dataCheck().pushSend([
+      this.dataCheck().pushSendOnline([
         {
           kind: Message.kind.canvas3DReq,
           M: this.member_,

--- a/src/client.ts
+++ b/src/client.ts
@@ -28,7 +28,7 @@ export class Client extends Member {
     logLevel: "trace" | "verbose" | "none" = "none"
   ) {
     super(new Field(new ClientData(name, host, port, logLevel), name), name);
-    clientWs.syncDataFirst(this.dataCheck());
+    // clientWs.syncDataFirst(this.dataCheck());
   }
   get logLevel() {
     return this.dataCheck().logLevel;
@@ -60,7 +60,13 @@ export class Client extends Member {
    */
   sync() {
     this.start();
-    clientWs.syncData(this.dataCheck(), false);
+    if (!this.connected && this.dataCheck().syncFirst === null) {
+      clientWs.initSyncDataFirst(this.dataCheck());
+    } else {
+      this.dataCheck().pushSendAlways(
+        clientWs.syncData(this.dataCheck(), false)
+      );
+    }
   }
 
   /**

--- a/src/clientData.ts
+++ b/src/clientData.ts
@@ -1,5 +1,5 @@
 import isEqual from "lodash.isequal";
-import { FuncInfo, AsyncFuncResult } from "./func.js";
+import { FuncInfo, FuncPromiseData } from "./func.js";
 import { EventEmitter } from "eventemitter3";
 import { LogLine } from "./log.js";
 import * as Message from "./message.js";
@@ -395,10 +395,10 @@ export class SyncDataStore1<T> {
 }
 
 export class FuncResultStore {
-  results: AsyncFuncResult[] = [];
+  results: FuncPromiseData[] = [];
   addResult(caller: string, base: Field) {
     const callerId = this.results.length;
-    this.results.push(new AsyncFuncResult(callerId, caller, base));
+    this.results.push(new FuncPromiseData(callerId, caller, base));
     return this.results[callerId];
   }
   getResult(callerId: number) {

--- a/src/clientData.ts
+++ b/src/clientData.ts
@@ -125,12 +125,26 @@ export class ClientData {
       return this.memberIds.get(name) || 0;
     }
   }
+
   /**
-   * messageQueueを消費
+   * 次回接続後一番最初に送信するメッセージ
+   * 
+   * * syncDataFirst() の返り値であり、
+   * すべてのリクエストとすべてのsyncデータ(1時刻分)が含まれる
+   * * sync()時に未接続かつこれが空ならその時点のsyncDataFirstをこれにセット
+   * * 接続時にこれが空でなければ、
+   *   * これ + messageQueueの中身(=syncDataFirst以降のすべてのsync()データ) を、
+   *   * これが空ならその時点のsyncDataFirstを、
+   * * 送信する
+   * * 送信したら再度これを空にする
+   */
+  syncFirst: ArrayBuffer | null = null;
+  /**
+   * メッセージを追加 & messageQueueを消費
    *
    * messageQueueになにか追加するところで呼ぶこと
    */
-  pushSend(msgs?: Message.AnyMessage[]) {
+  pushSendAlways(msgs?: Message.AnyMessage[]) {
     if (msgs != undefined) {
       this.messageQueue.push(Message.pack(msgs));
     }
@@ -139,6 +153,23 @@ export class ClientData {
         this.ws.send(msg);
       }
       this.messageQueue = [];
+    }
+  }
+  /**
+   * 接続されている場合に限ってメッセージを追加しtrueを返す
+   */
+  pushSendOnline(msgs?: Message.AnyMessage[]) {
+    if (this.ws != null) {
+      if (msgs != undefined) {
+        this.messageQueue.push(Message.pack(msgs));
+      }
+      for (const msg of this.messageQueue) {
+        this.ws.send(msg);
+      }
+      this.messageQueue = [];
+      return true;
+    }else{
+      return false;
     }
   }
 }

--- a/src/clientWs.ts
+++ b/src/clientWs.ts
@@ -441,7 +441,7 @@ export function onMessage(
         const dataR = msg as Message.CallResponse;
         const r = data.funcResultStore.getResult(dataR.i);
         if (r !== undefined) {
-          r.resolveStarted(dataR.s);
+          r.resolveReach(dataR.s);
         } else {
           data.consoleLogger.error(`error receiving call result id=${dataR.i}`);
         }
@@ -452,9 +452,9 @@ export function onMessage(
         const r = data.funcResultStore.getResult(dataR.i);
         if (r !== undefined) {
           if (dataR.e) {
-            r.rejectResult(new Error(String(dataR.r)));
+            r.rejectFinish(new Error(String(dataR.r)));
           } else {
-            r.resolveResult(dataR.r);
+            r.resolveFinish(dataR.r);
           }
         } else {
           data.consoleLogger.error(`error receiving call result id=${dataR.i}`);

--- a/src/func.ts
+++ b/src/func.ts
@@ -28,42 +28,74 @@ export class FuncNotFoundError extends Error {
   }
 }
 
-/**
- * 非同期で実行した関数の実行結果を表す。
- */
-export class AsyncFuncResult extends Field {
+export class FuncPromiseData {
   callerId: number;
   caller: string;
-  resolveStarted: (r: boolean) => void = () => undefined;
-  resolveResult: (r: Val | Promise<Val>) => void = () => undefined;
+  reach: Promise<boolean>;
+  resolveReach: (r: boolean) => void = () => undefined;
+  finish: Promise<Val>;
+  resolveFinish: (r: Val | Promise<Val>) => void = () => undefined;
   // 例外をセットする
-  rejectResult: (e: any) => void = () => undefined;
-  /**
-   * 関数が開始したらtrue, 存在しなければfalse
-   *
-   * falseの場合自動でresultにもFuncNotFoundErrorが入る
-   */
-  started: Promise<boolean>;
-  /**
-   * 実行結果または例外
-   */
-  result: Promise<Val>;
+  rejectFinish: (e: Error) => void = () => undefined;
+  base: Field;
+
   constructor(callerId: number, caller: string, base: Field) {
-    super(base.data, base.member_, base.field_);
+    this.base = base;
     this.callerId = callerId;
     this.caller = caller;
-    this.started = new Promise((res) => {
-      this.resolveStarted = (r: boolean) => {
+    this.reach = new Promise((res) => {
+      this.resolveReach = (r: boolean) => {
         res(r);
         if (!r) {
-          this.rejectResult(new FuncNotFoundError(this));
+          this.rejectFinish(new FuncNotFoundError(this.base));
         }
       };
     });
-    this.result = new Promise((res, rej) => {
-      this.resolveResult = res;
-      this.rejectResult = rej;
+    this.finish = new Promise((res, rej) => {
+      this.resolveFinish = res;
+      this.rejectFinish = rej;
     });
+  }
+  getter(){
+    return new FuncPromise(this);
+  }
+}
+/**
+ * 非同期で実行した関数の実行結果を表す。
+ */
+export class FuncPromise extends Field {
+  /**
+   * 関数呼び出しのメッセージが相手のクライアントに到達したら解決するPromise
+   * @since ver1.8
+   * 
+   * * 相手のクライアントが関数の実行を開始したらtrue、
+   * 指定したクライアントまたは関数が存在しなかった場合falseを返す
+   * * falseの場合自動でresultにもFuncNotFoundErrorが入る
+   */
+  reach: Promise<boolean>;
+  /**
+   * reach と同じ。
+   * @deprecated ver1.8〜
+   */
+  started: Promise<boolean>;
+  /**
+   * 関数の実行が完了し戻り値かエラーメッセージを受け取ったら解決するPromise
+   * @since ver1.8
+   * 
+   * * 関数の戻り値をstring,number,booleanのいずれかで返す。
+   * * 関数が例外を返した場合、 Error(エラーメッセージ) の値でrejectする。
+   *   * ver1.7以前ではany型だったが、1.8以降任意の例外をStringに変換した上でError型のメッセージにする
+   */
+  finish: Promise<string | number | boolean>
+  /**
+   * finish と同じ
+   * @deprecated ver1.8〜
+   */
+  result: Promise<Val>;
+  constructor(pData: FuncPromiseData) {
+    super(pData.base.data, pData.base.member_, pData.base.field_);
+    this.reach = this.started = pData.reach;
+    this.finish = this.result = pData.finish;
   }
   /**
    * 関数のMember
@@ -78,6 +110,8 @@ export class AsyncFuncResult extends Field {
     return this.field_;
   }
 }
+export const AsyncFuncResult = FuncPromise;
+export type AsyncFuncResult = FuncPromise;
 
 export function runFunc(fi: FuncInfo, args: Val[]) {
   if (fi.args.length === args.length) {
@@ -184,26 +218,30 @@ export class Func extends Field {
   free() {
     this.dataCheck().funcStore.unsetRecv(this.member_, this.field_);
   }
-  runImpl(r: AsyncFuncResult, args: Val[]) {
+  runImpl(r: FuncPromiseData, args: Val[]) {
     const funcInfo = this.dataCheck().funcStore.getRecv(
       this.member_,
       this.field_
     );
     if (this.dataCheck().isSelf(this.member_)) {
       if (funcInfo !== null && funcInfo.funcImpl !== undefined) {
-        r.resolveStarted(true);
+        r.resolveReach(true);
         try {
           // funcImplがpromise返す場合もそのままresolveにぶちこめばよいはず
           let res: Val | Promise<Val> | void = runFunc(funcInfo, args);
           if (res === undefined) {
             res = "";
           }
-          r.resolveResult(res);
+          r.resolveFinish(res);
         } catch (e: any) {
-          r.rejectResult(e);
+          if(e instanceof Error){
+            r.rejectFinish(e);
+          }else{
+            r.rejectFinish(new Error(String(e)));
+          }
         }
       } else {
-        r.resolveStarted(false);
+        r.resolveReach(false);
       }
     } else {
       this.dataCheck().pushSend([
@@ -221,17 +259,14 @@ export class Func extends Field {
   /**
    * 関数を実行する (非同期)
    *
-   * 戻り値やエラー、例外はAsyncFuncResultから取得する
-   *
-   * * 例外が発生した場合そのままthrow, 関数が存在しない場合 FuncNotFoundError をthrowする
-   * * リモートで実行し例外が発生した場合、例外は Error クラスになる
+   * 戻り値やエラー、例外はFuncPromiseから取得する
    */
   runAsync(...args: Val[]) {
     const r = this.dataCheck().funcResultStore.addResult("", this);
     setTimeout(() => {
       this.runImpl(r, args);
     });
-    return r;
+    return r.getter();
   }
   /**
    * 関数が存在すればtrueを返す

--- a/src/func.ts
+++ b/src/func.ts
@@ -244,7 +244,7 @@ export class Func extends Field {
         r.resolveReach(false);
       }
     } else {
-      this.dataCheck().pushSend([
+      if(!this.dataCheck().pushSendOnline([
         {
           kind: Message.kind.call,
           i: r.callerId,
@@ -253,7 +253,10 @@ export class Func extends Field {
           f: this.field_,
           a: args,
         },
-      ]);
+      ])){
+        // 未接続でfalseになる
+        r.resolveReach(false);
+      }
     }
   }
   /**

--- a/src/image.ts
+++ b/src/image.ts
@@ -100,7 +100,7 @@ export class Image extends EventTarget<Image> {
     );
     if (reqId > 0) {
       this.dataCheck().imageStore.clearRecv(this.member_, this.field_);
-      this.dataCheck().pushSend([
+      this.dataCheck().pushSendOnline([
         {
           kind: Message.kind.imageReq,
           M: this.member_,

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,7 @@ export {
   canvas2DComponentType,
 } from "./canvas2d.js";
 export { valType } from "./message.js";
-export { Arg, Func, AsyncFuncResult, FuncNotFoundError } from "./func.js";
+export { Arg, Func, FuncPromise, AsyncFuncResult, FuncNotFoundError } from "./func.js";
 export { EventTarget } from "./event.js";
 // export {} from "./field.js";
 import version_ from "./version.js";

--- a/src/log.ts
+++ b/src/log.ts
@@ -44,7 +44,7 @@ export class Log extends EventTarget<Log> {
   request() {
     const req = this.dataCheck().logStore.addReq(this.member_);
     if (req) {
-      this.dataCheck().pushSend([
+      this.dataCheck().pushSendOnline([
         {
           kind: Message.kind.logReq,
           M: this.member_,

--- a/src/member.ts
+++ b/src/member.ts
@@ -314,7 +314,7 @@ export class Member extends Field {
   get pingStatus() {
     if (!this.dataCheck().pingStatusReq) {
       this.dataCheck().pingStatusReq = true;
-      this.dataCheck().pushSend([
+      this.dataCheck().pushSendOnline([
         {
           kind: Message.kind.pingStatusReq,
         },

--- a/src/robotModel.ts
+++ b/src/robotModel.ts
@@ -154,7 +154,7 @@ export class RobotModel extends EventTarget<RobotModel> {
       this.field_
     );
     if (reqId > 0) {
-      this.dataCheck().pushSend([
+      this.dataCheck().pushSendOnline([
         {
           kind: Message.kind.robotModelReq,
           M: this.member_,

--- a/src/text.ts
+++ b/src/text.ts
@@ -48,7 +48,7 @@ export class Text extends EventTarget<Text> {
   request() {
     const reqId = this.dataCheck().textStore.addReq(this.member_, this.field_);
     if (reqId > 0) {
-      this.dataCheck().pushSend([
+      this.dataCheck().pushSendOnline([
         {
           kind: Message.kind.textReq,
           M: this.member_,

--- a/src/value.ts
+++ b/src/value.ts
@@ -48,7 +48,7 @@ export class Value extends EventTarget<Value> {
   request() {
     const reqId = this.dataCheck().valueStore.addReq(this.member_, this.field_);
     if (reqId > 0) {
-      this.dataCheck().pushSend([
+      this.dataCheck().pushSendOnline([
         {
           kind: Message.kind.valueReq,
           M: this.member_,

--- a/src/view.ts
+++ b/src/view.ts
@@ -450,7 +450,7 @@ export class View extends EventTarget<View> {
   request() {
     const reqId = this.dataCheck().viewStore.addReq(this.member_, this.field_);
     if (reqId > 0) {
-      this.dataCheck().pushSend([
+      this.dataCheck().pushSendOnline([
         {
           kind: Message.kind.viewReq,
           M: this.member_,

--- a/test/client.spec.ts
+++ b/test/client.spec.ts
@@ -1001,7 +1001,7 @@ describe("Client Tests", function () {
         setTimeout(() => {
           data.memberIds.set("a", 10);
           const r = new FuncPromiseData(1, "", new Field(data, "a", "b"));
-          data.pushSend([
+          data.pushSendAlways([
             {
               kind: Message.kind.call,
               i: r.callerId,
@@ -1035,7 +1035,7 @@ describe("Client Tests", function () {
             new Field(data, "a", "b")
           );
           assert.strictEqual(r.callerId, 0);
-          data.pushSend([
+          data.pushSendAlways([
             {
               kind: Message.kind.call,
               i: r.callerId,
@@ -1075,7 +1075,7 @@ describe("Client Tests", function () {
             "",
             new Field(data, "a", "b")
           );
-          data.pushSend([
+          data.pushSendAlways([
             {
               kind: Message.kind.call,
               i: r.callerId,
@@ -1122,7 +1122,7 @@ describe("Client Tests", function () {
             "",
             new Field(data, "a", "b")
           );
-          data.pushSend([
+          data.pushSendAlways([
             {
               kind: Message.kind.call,
               i: r.callerId,

--- a/test/client.spec.ts
+++ b/test/client.spec.ts
@@ -8,7 +8,7 @@ import { Text } from "../src/text.js";
 import { RobotModel, RobotLink } from "../src/robotModel.js";
 import { Transform } from "../src/transform.js";
 import { Geometry } from "../src/canvas3d.js";
-import { Func, AsyncFuncResult, FuncNotFoundError } from "../src/func.js";
+import { Func, FuncNotFoundError, FuncPromiseData } from "../src/func.js";
 import { valType } from "../src/message.js";
 import { View, viewComponents } from "../src/view.js";
 import { Field } from "../src/field.js";
@@ -1000,7 +1000,7 @@ describe("Client Tests", function () {
         wcli.start();
         setTimeout(() => {
           data.memberIds.set("a", 10);
-          const r = new AsyncFuncResult(1, "", new Field(data, "a", "b"));
+          const r = new FuncPromiseData(1, "", new Field(data, "a", "b"));
           data.pushSend([
             {
               kind: Message.kind.call,
@@ -1052,11 +1052,11 @@ describe("Client Tests", function () {
               c: 0,
               s: false,
             });
-            r.started
-              .then((started) => assert.isFalse(started))
+            r.getter()
+              .started.then((started) => assert.isFalse(started))
               .catch(() => assert.fail("r.started threw error"));
-            r.result
-              .then(() => {
+            r.getter()
+              .result.then(() => {
                 assert.fail("r.result did not throw error");
                 done();
               })
@@ -1099,11 +1099,11 @@ describe("Client Tests", function () {
               e: true,
               r: "aaa",
             });
-            r.started
-              .then((started) => assert.isFalse(started))
+            r.getter()
+              .started.then((started) => assert.isFalse(started))
               .catch(() => assert.fail("r.started threw error"));
-            r.result
-              .then(() => {
+            r.getter()
+              .result.then(() => {
                 assert.fail("r.result did not throw error");
                 done();
               })
@@ -1146,11 +1146,11 @@ describe("Client Tests", function () {
               e: false,
               r: "aaa",
             });
-            r.started
-              .then((started) => assert.isTrue(started))
+            r.getter()
+              .started.then((started) => assert.isTrue(started))
               .catch(() => assert.fail("r.started threw error"));
-            r.result
-              .then((res) => {
+            r.getter()
+              .result.then((res) => {
                 assert.strictEqual(res, "aaa");
                 done();
               })

--- a/test/clientData.spec.ts
+++ b/test/clientData.spec.ts
@@ -278,8 +278,8 @@ describe("ClientData Tests", function () {
       it("returns result object", function () {
         const r = fs.addResult("a", new Field(data, "b", "c"));
         assert.strictEqual(r.caller, "a");
-        assert.strictEqual(r.member.name, "b");
-        assert.strictEqual(r.name, "c");
+        assert.strictEqual(r.getter().member.name, "b");
+        assert.strictEqual(r.getter().name, "c");
         assert.strictEqual(r.callerId, 0);
       });
     });
@@ -288,8 +288,8 @@ describe("ClientData Tests", function () {
         fs.addResult("a", new Field(data, "b", "c"));
         const r = fs.getResult(0);
         assert.strictEqual(r.caller, "a");
-        assert.strictEqual(r.member.name, "b");
-        assert.strictEqual(r.name, "c");
+        assert.strictEqual(r.getter().member.name, "b");
+        assert.strictEqual(r.getter().name, "c");
         assert.strictEqual(r.callerId, 0);
       });
     });

--- a/test/func.spec.ts
+++ b/test/func.spec.ts
@@ -80,24 +80,25 @@ describe("Func Tests", function () {
         ])
       );
     });
-    it("calls function with casted arguments, and returns AsyncFuncResult object", async function () {
+    it("calls function with casted arguments, and returns FuncPromise object", async function () {
       const r = func(selfName, "a").runAsync(5, "123", 1);
-      assert.strictEqual(r.callerId, 0);
+      // assert.strictEqual(r.callerId, 0);
       assert.strictEqual(r.member.name, selfName);
       assert.strictEqual(r.name, "a");
       assert.isTrue(await r.started);
+      assert.isTrue(await r.reach);
       assert.strictEqual(await r.result, "test");
+      assert.strictEqual(await r.finish, "test");
       assert.strictEqual(called, 1);
     });
     it("returns AsyncFuncResult object which throws Error when fewer argument passed", function (done) {
       const r = func(selfName, "a").runAsync();
-      r.started
+      r.reach
         .then((started) => assert.isFalse(started))
         .catch(() => assert.fail("r.started threw error"));
-      r.result
+      r.finish
         .then(() => {
           assert.fail("r.result did not throw error");
-          done();
         })
         .catch((e) => {
           assert.instanceOf(e, Error);
@@ -106,10 +107,10 @@ describe("Func Tests", function () {
     });
     it("returns AsyncFuncResult object which throws Error when more argument passed", function (done) {
       const r = func(selfName, "a").runAsync(1, 2, 3, 4, 5);
-      r.started
+      r.reach
         .then((started) => assert.isFalse(started))
         .catch(() => assert.fail("r.started threw error"));
-      r.result
+      r.finish
         .then(() => {
           assert.fail("r.result did not throw error");
           done();

--- a/test/func.spec.ts
+++ b/test/func.spec.ts
@@ -135,19 +135,31 @@ describe("Func Tests", function () {
           done();
         });
     });
-    it("push call message to data.messageQueue when member is not self", function (done) {
+    it("send call message when member is not self and ws is not null", function (done) {
+      data.memberIds.set("a", 10);
+      let send_called = 0;
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      data.ws = {
+        send: (msg: ArrayBuffer) => {
+          send_called++;
+          const msg0 = Message.unpack(msg)[0] as Message.Call;
+          assert.strictEqual(msg0.i, 0);
+          assert.strictEqual(msg0.r, 10);
+          assert.strictEqual(msg0.f, "b");
+          assert.sameOrderedMembers(msg0.a, ["5", 123, true]);
+        },
+      } as any;
+      func("a", "b").runAsync("5", 123, true);
+      setTimeout(() => {
+        assert.strictEqual(send_called, 1);
+        done();
+      }, 10);
+    });
+    it("do not push call message to data.messageQueue when ws is null", function (done) {
       data.memberIds.set("a", 10);
       func("a", "b").runAsync("5", 123, true);
       setTimeout(() => {
-        assert.lengthOf(data.messageQueue, 1);
-        const msg = Message.unpack(data.messageQueue[0]);
-        assert.lengthOf(msg, 1);
-        const msg0 = msg[0] as Message.Call;
-        assert.strictEqual(msg0.i, 0);
-        assert.strictEqual(msg0.r, 10);
-        assert.strictEqual(msg0.f, "b");
-        assert.sameOrderedMembers(msg0.a, ["5", 123, true]);
-
+        assert.isEmpty(data.messageQueue);
         done();
       }, 10);
     });


### PR DESCRIPTION
- AsyncFuncResult→FuncPromise
  - started→reach、result→finish
  - finishのエラー値が常にError型で返るようにした
  - setter関数などをFuncPromiseDataクラスに分離
- syncDataFirstの仕様をC++に合わせた
  - クライアントが未接続のときrunAsync()は関数呼び出しを送信しない

